### PR TITLE
Add Snappy dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update \
     git \
     gzip \
     make \
+    libc6-compat \
     tar
 
 ENV SPARK_HOME=/usr/spark/spark-2.1.0-bin-hadoop2.7 \


### PR DESCRIPTION
If commands involving Snappy is invoked, error occurs due to missing dependency of Snappy. E.g.:

```sh
$ docker run -it --rm -v $PWD:/tmp/working -w /tmp/working shusson/hail-alpine \
	read -i sample.vds \
	exportvariants -c 'v' -o test.txt
...
2017-03-02 13:36:19 ERROR Utils:91 - Aborting task
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.2-bf55aef3-ffe7-49f5-b8c2-8925c3268d60-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed
 by /tmp/snappy-1.1.2-bf55aef3-ffe7-49f5-b8c2-8925c3268d60-libsnappyjava.so)
```

Adding `libc6-compat` is probably the simplest solution.
Thanks to relateiq/docker-kafka#12.